### PR TITLE
Fix race condition arming hardware timer before storing callback in IntervalTimerEx

### DIFF
--- a/src/IntervalTimerEx/IntervalTimerEx.cpp
+++ b/src/IntervalTimerEx/IntervalTimerEx.cpp
@@ -17,7 +17,7 @@ void IntervalTimerEx::end()
 
 
 // generate and preset the callback storage
-IntervalTimerEx::callback_t IntervalTimerEx::callbacks[4]{
+callback_t IntervalTimerEx::callbacks[4]{
     nullptr,
     nullptr,
     nullptr,
@@ -26,7 +26,7 @@ IntervalTimerEx::callback_t IntervalTimerEx::callbacks[4]{
 
 #if defined (USE_CPP11_CALLBACKS)
 
-IntervalTimerEx::relay_t IntervalTimerEx::relays[4]{
+relay_t IntervalTimerEx::relays[4]{
     [] { callbacks[0](); },
     [] { callbacks[1](); },
     [] { callbacks[2](); },
@@ -36,7 +36,7 @@ IntervalTimerEx::relay_t IntervalTimerEx::relays[4]{
 #else
 
 // generate the static array of relay functions
-IntervalTimerEx::relay_t IntervalTimerEx::relays[4]{
+relay_t IntervalTimerEx::relays[4]{
     [] { callbacks[0](states[0]); },
     [] { callbacks[1](states[1]); },
     [] { callbacks[2](states[2]); },

--- a/src/IntervalTimerEx/IntervalTimerEx.cpp
+++ b/src/IntervalTimerEx/IntervalTimerEx.cpp
@@ -8,13 +8,16 @@ IntervalTimerEx::~IntervalTimerEx()
 
 void IntervalTimerEx::end()
 {
-    callbacks[index] = nullptr;
     IntervalTimer::end();
+    uint32_t primask;
+    asm volatile("mrs %0, primask\n\t cpsid i" : "=r"(primask)::"memory");
+    callbacks[index] = nullptr;
+    asm volatile("msr primask, %0" ::"r"(primask) : "memory");
 }
 
 
 // generate and preset the callback storage
-callback_t IntervalTimerEx::callbacks[4]{
+IntervalTimerEx::callback_t IntervalTimerEx::callbacks[4]{
     nullptr,
     nullptr,
     nullptr,
@@ -23,7 +26,7 @@ callback_t IntervalTimerEx::callbacks[4]{
 
 #if defined (USE_CPP11_CALLBACKS)
 
-relay_t IntervalTimerEx::relays[4]{
+IntervalTimerEx::relay_t IntervalTimerEx::relays[4]{
     [] { callbacks[0](); },
     [] { callbacks[1](); },
     [] { callbacks[2](); },
@@ -33,7 +36,7 @@ relay_t IntervalTimerEx::relays[4]{
 #else
 
 // generate the static array of relay functions
-relay_t IntervalTimerEx::relays[4]{
+IntervalTimerEx::relay_t IntervalTimerEx::relays[4]{
     [] { callbacks[0](states[0]); },
     [] { callbacks[1](states[1]); },
     [] { callbacks[2](states[2]); },

--- a/src/IntervalTimerEx/IntervalTimerEx.h
+++ b/src/IntervalTimerEx/IntervalTimerEx.h
@@ -5,21 +5,18 @@
 #define USE_CPP11_CALLBACKS                    // comment out if you want to use the traditional void pointer pattern to pass state to callbacks
 
 #if defined(USE_CPP11_CALLBACKS)
-  #include <functional>
+#include <functional>
+    using callback_t = std::function<void()>;
+    using relay_t = void (*)();
+
+#else
+    using callback_t = void (*)(void*);
+    using relay_t = void (*)();
 #endif
 
 
 class IntervalTimerEx : public IntervalTimer
 {
- public:
-    #if defined(USE_CPP11_CALLBACKS)
-        using callback_t = std::function<void()>;
-        using relay_t = void (*)();
-
-    #else
-        using callback_t = void (*)(void*);
-        using relay_t = void (*)();
-    #endif
  public:
     template <typename period_t>               // begin is implemented as template to avoid replication the various versions of IntervalTimer::begin
     #if defined(USE_CPP11_CALLBACKS)
@@ -46,7 +43,7 @@ class IntervalTimerEx : public IntervalTimer
 
  #if defined(USE_CPP11_CALLBACKS)
 template <typename period_t>
-bool IntervalTimerEx::begin(callback_t callback, period_t period)
+bool IntervalTimerEx::begin(std::function<void()> callback, period_t period)
 {
     uint32_t primask;
     asm volatile("mrs %0, primask\n\t cpsid i" : "=r"(primask)::"memory");

--- a/src/IntervalTimerEx/IntervalTimerEx.h
+++ b/src/IntervalTimerEx/IntervalTimerEx.h
@@ -6,17 +6,20 @@
 
 #if defined(USE_CPP11_CALLBACKS)
   #include <functional>
-  using callback_t = std::function<void()>;
-  using relay_t = void (*)();
-
-#else
-  using callback_t = void (*)(void*);
-  using relay_t = void (*)();
 #endif
 
 
 class IntervalTimerEx : public IntervalTimer
 {
+ public:
+    #if defined(USE_CPP11_CALLBACKS)
+        using callback_t = std::function<void()>;
+        using relay_t = void (*)();
+
+    #else
+        using callback_t = void (*)(void*);
+        using relay_t = void (*)();
+    #endif
  public:
     template <typename period_t>               // begin is implemented as template to avoid replication the various versions of IntervalTimer::begin
     #if defined(USE_CPP11_CALLBACKS)
@@ -43,20 +46,25 @@ class IntervalTimerEx : public IntervalTimer
 
  #if defined(USE_CPP11_CALLBACKS)
 template <typename period_t>
-bool IntervalTimerEx::begin(std::function<void()> callback, period_t period)
+bool IntervalTimerEx::begin(callback_t callback, period_t period)
 {
+    uint32_t primask;
+    asm volatile("mrs %0, primask\n\t cpsid i" : "=r"(primask)::"memory");
     for (index = 0; index < 4; index++) // find the next free slot
     {
         if (callbacks[index] == nullptr) // ->free slot
         {
-            if (IntervalTimer::begin(relays[index], period)) // we got a slot but we need to also get an actual timer
+            callbacks[index] = callback; // store callback before arming the timer
+            asm volatile("msr primask, %0" ::"r"(primask) : "memory");
+            if (IntervalTimer::begin(relays[index], period)) // now arm an actual timer
             {
-                callbacks[index] = callback; // if ok -> store callback
                 return true;
             }
+            callbacks[index] = nullptr; // arming failed -> release the slot
             return false;
         }
     }
+    asm volatile("msr primask, %0" ::"r"(primask) : "memory");
     return false; // can never happen if bookkeeping is ok
 }
 


### PR DESCRIPTION
begin() has the possibility to arm the timer before storing the std::function callback_t. Landing a hardware timer interrupt in that window invokes an empty function causing a hard fault. This can occur when running the IntervalTimerEx fast enough resulting in opaque crashes.
end() has the opposite error where it clears the callback before stopping the timer resulting in the possibility of interrupting the timer with a cleared callback.

This bug occurs on my Teensy 4.1 specifically in the EncSim library driving the encoder simulators extremely quickly churning the begin() and end() calls quickly. I used the stack trace to confirm a std::__throw_bad_function_call naming these mechanisms invoking an empty std::function. I confirmed this issue using a non fatal guard in the relay confirming a race condition. 

IntervalTimerEx::relay_t IntervalTimerEx::relays[4]{
    [] { if (callbacks[0]) callbacks[0](); else ++missCount[0]; },
    [] { if (callbacks[1]) callbacks[1](); else ++missCount[1]; },
    [] { if (callbacks[2]) callbacks[2](); else ++missCount[2]; },
    [] { if (callbacks[3]) callbacks[3](); else ++missCount[3]; },
};

Printing these missCounts confirms multiple missed callbacks occurring. 

Fixed by using a PRIMASK to prevent hardware interrupt timers from being able to fire in the middle of writing the callback location in both begin() and end().

I also fixed the IntervalTimerEx static definitions of callback_t to avoid shadowing the IntervalTimer::callback_t